### PR TITLE
media_type_file_fields is a dict not a list

### DIFF
--- a/docs/media_types.md
+++ b/docs/media_types.md
@@ -91,7 +91,7 @@ Here's an example that tells Workbench that the custom media type "Custom media"
 
 ```yaml
 media_type_file_fields:
- - my_custom_media: field_media_file
+  my_custom_media: field_media_file
 ```
 
 Put together, the two configuration options would look like this:
@@ -100,7 +100,7 @@ Put together, the two configuration options would look like this:
 media_types_override:
   - my_custom_media: ['cus']
 media_type_file_fields:
- - my_custom_media: field_media_file
+  my_custom_media: field_media_file
 ```
 
 In this example, your Workbench job is creating media of varying types (for example, images, videos, and documents, all using the default extension-to-media type mappings. If all the files you are adding in the Workbench job all have the same media type (in the following example, your "my_custom_media" type), you could use this configuration:
@@ -108,6 +108,6 @@ In this example, your Workbench job is creating media of varying types (for exam
 ```yaml
 media_type: my_custom_media
 media_type_file_fields:
- - my_custom_media: field_media_file
+  my_custom_media: field_media_file
 ```
 


### PR DESCRIPTION
Using
```
task: add_media
```

When passing a list for `media_type_file_fields` in the config, as:
```
media_use_tid: http://pcdm.org/use#OriginalFile
media_type: findingaid
media_types_override:
  - findingaid: ['xml', 'ead']
media_type_file_fields:
  - findingaid: field_media_file
standalone_media_url: true
```
encountered the following error:
```
╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
│ /usr/local/bin/workbench:3575 in <module>                                                        │
│                                                                                                  │
│   3572 │   │   │   if config["task"] == "create_from_files":                                     │
│   3573 │   │   │   │   check_input_for_create_from_files(config, args)                           │
│   3574 │   │   │   else:                                                                         │
│ ❱ 3575 │   │   │   │   check_input(config, args)                                                 │
│   3576 except KeyboardInterrupt:                                                                 │
│   3577 │   print("Exiting before entire --check completed.")                                     │
│   3578 │   logging.warning('Workbench exiting after receiving "ctrl-c" during --check.')         │
│                                                                                                  │
│ /opt/islandora_workbench/workbench_utils.py:3597 in check_input                                  │
│                                                                                                  │
│    3594 │   │   │   │   │   │   │   │   extension = os.path.splitext(file_check_row["file"])[1]  │
│    3595 │   │   │   │   │   │   │   │   extension = extension.lstrip(".").lower()                │
│    3596 │   │   │   │   │   │   │   logging.error(str(config["media_type_file_fields"]))         │
│ ❱  3597 │   │   │   │   │   │   │   media_type_file_field = config["media_type_file_fields"][    │
│    3598 │   │   │   │   │   │   │   │   media_type                                               │
│    3599 │   │   │   │   │   │   │   ]                                                            │
│    3600 │   │   │   │   │   │   │   registered_extensions = get_registered_media_extensions(     │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
TypeError: list indices must be integers or slices, not str
```

Syntax as a dict passes `--check`:
```
media_use_tid: http://pcdm.org/use#OriginalFile
media_type: findingaid
media_types_override:
  - findingaid: ['xml', 'ead']
media_type_file_fields:
  findingaid: field_media_file
standalone_media_url: true
```